### PR TITLE
fix(charts): charts query correction for optimize it

### DIFF
--- a/superset/charts/filters.py
+++ b/superset/charts/filters.py
@@ -120,7 +120,7 @@ class ChartFilter(BaseFilter):  # pylint: disable=too-few-public-methods
         if is_feature_enabled("DATASET_RBAC"):
             # Roles access
             roles_based_query = get_datasets_authorized_for_user_roles()
-            feature_flagged_filters.append(SqlaTable.id.in_(roles_based_query))
+            feature_flagged_filters.append(table_alias.id.in_(roles_based_query))
 
             # Owners access
             owners_based_query = get_charts_authorized_for_owners()


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Use alias table instead of table named "tables" directly for avoid an unnecessary "join" and costly in terms of performance.

Extract of join from previous query
```sql
FROM tables, slices JOIN tables AS tables_1 ON slices.datasource_id = tables_1.id JOIN dbs 
ON tables_1.database_id = dbs.id 
```

Extract of join from new query all items use aliased table "tables_1"
```sql
FROM slices JOIN tables AS tables_1 ON slices.datasource_id = tables_1.id JOIN dbs 
ON tables_1.database_id = dbs.id 
```

PLAID-124176

PLAID-133424
