### PR TITLE
fix(schemas): handle schemas when database contains dots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@
 *.sqllite
 *.swp
 __pycache__
-
+.venv
 .local
 .cache
 .bento*

--- a/superset/databases/filters.py
+++ b/superset/databases/filters.py
@@ -25,6 +25,7 @@ from sqlalchemy.sql.sqltypes import JSON
 
 from superset import app, security_manager
 from superset.models.core import Database
+from superset.utils.database import parse_resource
 from superset.views.base import BaseFilter
 
 
@@ -33,7 +34,7 @@ def can_access_databases(view_menu_name: str) -> set[str]:
     Return names of databases available in `view_menu_name`.
     """
     return {
-        vm[1 : vm.index("]")]
+        parse_resource(vm)[0]
         for vm in security_manager.user_view_menu_names(view_menu_name)
     }
 

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -75,6 +75,7 @@ from superset.utils.core import (
     get_user_id,
     RowLevelSecurityFilterType,
 )
+from superset.utils.database import parse_resource
 from superset.utils.filters import get_dataset_access_filters
 from superset.utils.urls import get_url_host
 
@@ -809,7 +810,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         default_schema = database.get_default_schema(default_catalog)
 
         for perm in schema_access:
-            parts = [part[1:-1] for part in perm.split(".")]
+            parts = parse_resource(perm)
 
             if parts[0] != database.database_name:
                 continue
@@ -869,14 +870,14 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         default_catalog = database.get_default_catalog()
 
         for perm in catalog_access:
-            parts = [part[1:-1] for part in perm.split(".")]
+            parts = parse_resource(perm)
             if parts[0] == database.database_name:
                 accessible_catalogs.add(parts[1])
 
         # schema access
         schema_access = self.user_view_menu_names("schema_access")
         for perm in schema_access:
-            parts = [part[1:-1] for part in perm.split(".")]
+            parts = parse_resource(perm)
 
             if parts[0] != database.database_name:
                 continue

--- a/superset/utils/database.py
+++ b/superset/utils/database.py
@@ -17,7 +17,8 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+import re
+from typing import List, TYPE_CHECKING
 
 from flask import current_app
 
@@ -80,3 +81,17 @@ def remove_database(database: Database) -> None:
 
     db.session.delete(database)
     db.session.flush()
+
+
+def parse_resource(resource_name: str) -> List[str]:
+    """
+    Parses a resource string looking like "[database].[catalog].[schema]" or
+    "[database].[schema]" and returns a list of its components.
+    Handles dots in any part.
+    """
+    if not resource_name:
+        return []
+
+    # Regex to match components within square brackets
+    pattern = r"\[(.*?)\]"
+    return re.findall(pattern, resource_name)

--- a/tests/unit_tests/utils/database.py
+++ b/tests/unit_tests/utils/database.py
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest  # noqa: F401
+
+from superset.utils.database import parse_resource
+
+
+def test_parse_resource():
+    assert parse_resource("[db].[catalog].[schema]") == ["db", "catalog", "schema"]
+    assert parse_resource("[db].[schema]") == ["db", "schema"]
+    assert parse_resource("[db.with.dots].[catalog.with.dots].[schema.with.dots]") == [
+        "db.with.dots",
+        "catalog.with.dots",
+        "schema.with.dots",
+    ]


### PR DESCRIPTION
## Summary

Part 2 of fixing "account with dots" issue. Now handles database schemas correctly 

## Screenshots

<img width="1524" height="838" alt="image" src="https://github.com/user-attachments/assets/ddfa567b-40ab-41ad-b534-9c3b9ecc7ada" />
