### PR TITLE
fix(dataset): update roles only if present in the request (#32)

### DIFF
--- a/superset/commands/dataset/update.py
+++ b/superset/commands/dataset/update.py
@@ -82,7 +82,6 @@ class UpdateDatasetCommand(UpdateMixin, BaseCommand):
     ) -> None:
         exceptions: list[ValidationError] = []
         owner_ids: Optional[list[int]] = self._properties.get("owners")
-        role_ids: Optional[list[int]] = self._properties.get("roles")
 
         # Validate/populate model exists
         self._model = DatasetDAO.find_by_id(self._model_id)
@@ -132,11 +131,14 @@ class UpdateDatasetCommand(UpdateMixin, BaseCommand):
             exceptions.append(ex)
 
         # Validate roles
-        try:
-            roles = populate_roles(role_ids)
-            self._properties["roles"] = roles
-        except ValidationError as ex:
-            exceptions.append(ex)
+        if "roles" in self._properties:
+            try:
+                role_ids = self._properties.get("roles")
+                roles = populate_roles(role_ids)
+                self._properties["roles"] = roles
+            except ValidationError as ex:
+                exceptions.append(ex)
+
         if exceptions:
             raise DatasetInvalidError(exceptions=exceptions)
 

--- a/tests/unit_tests/commands/dataset/test_update.py
+++ b/tests/unit_tests/commands/dataset/test_update.py
@@ -17,6 +17,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+from marshmallow import ValidationError
 from pytest_mock import MockerFixture
 
 from superset import db
@@ -58,3 +59,91 @@ def test_update_uniqueness_error(mocker: MockerFixture) -> None:
                 "schema": "qux",
             },
         ).run()
+
+
+@pytest.mark.usefixture("session")
+def test_update_validate_roles_when_in_payload(mocker: MockerFixture) -> None:
+    """When the payload contains "roles", `populate_roles` is called and
+    the resolved roles are stored in `command._properties["roles"]`."""
+    SqlaTable.metadata.create_all(db.session.get_bind())
+    database = Database(database_name="my_db_3", sqlalchemy_uri="sqlite://")
+    dataset = SqlaTable(table_name="bar", schema="foo", database=database)
+    db.session.add_all([database, dataset])
+    db.session.commit()
+
+    mock_g = mocker.patch("superset.security.manager.g")
+    mock_g.user = MagicMock()
+
+    # Allow DAO to see the created datasource
+    mocker.patch(
+        "superset.views.base.security_manager.can_access_all_datasources",
+        return_value=True,
+    )
+
+    mocker.patch(
+        "superset.commands.dataset.update.security_manager.raise_for_ownership",
+        return_value=None,
+    )
+    mocker.patch.object(UpdateDatasetCommand, "compute_owners", return_value=[])
+
+    resolved_roles = [MagicMock(id=1), MagicMock(id=2)]
+    populate_roles_mock = mocker.patch(
+        "superset.commands.dataset.update.populate_roles",
+        return_value=resolved_roles,
+    )
+
+    command = UpdateDatasetCommand(
+        dataset.id,
+        {
+            "table_name": "bar",
+            "schema": "foo",
+            "roles": [1, 2],
+        },
+    )
+    command.validate()
+
+    populate_roles_mock.assert_called_once_with([1, 2])
+    assert command._properties["roles"] == resolved_roles
+
+
+@pytest.mark.usefixture("session")
+def test_update_does_not_validate_roles_when_not_in_payload(
+    mocker: MockerFixture,
+) -> None:
+    SqlaTable.metadata.create_all(db.session.get_bind())
+    database = Database(database_name="my_db_2", sqlalchemy_uri="sqlite://")
+    dataset = SqlaTable(table_name="bar", schema="foo", database=database)
+    db.session.add_all([database, dataset])
+    db.session.commit()
+
+    mock_g = mocker.patch("superset.security.manager.g")
+    mock_g.user = MagicMock()
+
+    mocker.patch(
+        "superset.commands.dataset.update.security_manager.raise_for_ownership",
+        return_value=None,
+    )
+    mocker.patch.object(UpdateDatasetCommand, "compute_owners", return_value=[])
+
+    # autorise la visibilité de la datasource créée pour le DAO
+    mocker.patch(
+        "superset.views.base.security_manager.can_access_all_datasources",
+        return_value=True,
+    )
+
+    populate_roles_mock = mocker.patch(
+        "superset.commands.dataset.update.populate_roles",
+        side_effect=ValidationError("populate_roles should not be called"),
+    )
+
+    command = UpdateDatasetCommand(
+        dataset.id,
+        {
+            "table_name": "bar",
+            "schema": "foo",
+        },
+    )
+    command.validate()
+
+    populate_roles_mock.assert_not_called()
+    assert "roles" not in command._properties


### PR DESCRIPTION
PLAID-147378

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

With the feature we added to bring the possibility to give read-only access to a dataset to roles (https://github.com/MGDIS/superset/pull/2), we updated the configuration screen of a datasource, but the same API endpoint is called from the screen to save a query to a dataset.

Through this save the roles associated to the dataset were emptyed because role ids weren't a part of the query.

The fix of this PR consists not to update the roles if role ids aren't a part of the query. 


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

- Add roles to a dataset through its configuration screen
- Write a query from SQL lab
- Save the query towards the dataset
- Check that the dataset has kepts their roles

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
